### PR TITLE
Fix logging objects with no keys, e.g. dates

### DIFF
--- a/packages/gcloud-logger/src/Logger.ts
+++ b/packages/gcloud-logger/src/Logger.ts
@@ -177,8 +177,13 @@ export class Logger {
             return obj.map(item => replaceCircular(item, alreadySeen));
           }
 
+          const keys = Object.keys(obj);
+          if (keys.length === 0) {
+            return obj;
+          }
+
           const newObj: IObject = {};
-          Object.keys(obj).forEach(key => {
+          keys.forEach(key => {
             const val = replaceCircular(obj[key], alreadySeen);
             newObj[key] = val;
           });


### PR DESCRIPTION
When removing circular references objects that have no keys (e.g. dates) would be represented as empty objects in logs. We can safely return them immediately since they have no keys so they won't introduce circular refs.

REPL output to illustrate.

Before:
```
> logger.info('test', { createdAt: new Date() })
info: test {"createdAt":{}}
```

After:
```
> let d = new Date()
> logger.info('test', { createdAt: d, updatedAt: d })
info: test {"createdAt":"2020-08-18T10:45:34.316Z","updatedAt":"[CIRCULAR]"}
```