### PR TITLE
fix: JOIN-32845 fix missing warning logs for slow queries

### DIFF
--- a/packages/gcloud-typeorm-logger/src/index.ts
+++ b/packages/gcloud-typeorm-logger/src/index.ts
@@ -26,8 +26,8 @@ export class SqlLogger {
     this.logger.error(`query failed: ${query}`, { error, parameters })
   }
 
-  public logQuerySlow(time: number, query: string, parameters?: any[], _?: any) {
-    this.logger.warn(`query is slow: ${query}`, { time, parameters })
+  public logQuerySlow(queryTime: number, query: string, parameters?: any[], _?: any) {
+    this.logger.warn(`query is slow: ${query}`, { queryTime, parameters })
   }
 
   public logSchemaBuild(message: string, _?: any) {


### PR DESCRIPTION
Time is an internal field for cloud logging, and sending it as an integer to logs more likely causes a parsing error and all slow query warning logs disappear. Renaming time to queryTime fixes the issue

[JOIN-32845]

[JOIN-32845]: https://joinsolutionsag.atlassian.net/browse/JOIN-32845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ