### PR TITLE
fix: TECH check if body exists before extracting operation name

### DIFF
--- a/packages/gcloud-express-logger/src/index.ts
+++ b/packages/gcloud-express-logger/src/index.ts
@@ -20,7 +20,7 @@ const requestLogMessage = (req: Request, res: Response, ms: number) => ({
 })
 
 const requestOperationName = (req: Request): string | undefined => {
-  if ('operationName' in req.body && typeof req.body.operationName === 'string') {
+  if (req.body && 'operationName' in req.body && typeof req.body.operationName === 'string') {
     return req.body.operationName
   }
 


### PR DESCRIPTION
on FE for some request we got
```
TypeError: Cannot use 'in' operator to search for 'operationName' in undefined
```